### PR TITLE
chore: 🔧 enforce strict branch protection

### DIFF
--- a/holocron.config.json
+++ b/holocron.config.json
@@ -4,7 +4,7 @@
   "repo": {
     "name": "theholocron/<name>",
     "teams": [{ "slug": "gatekeepers", "permission": "maintain" }],
-    "protection": "balanced",
+    "protection": "strict",
     "topics": [],
     "properties": {
       "lifecycle": "active",


### PR DESCRIPTION
## Summary

- Sets `"protection": "strict"` — requires DCO + Lint to pass before merge (no test/typecheck workflows exist in this repo)

## Test plan

- [ ] Merge and run `holocron setup` to apply the ruleset change to GitHub